### PR TITLE
lib: tidy up with the RustFMT tool

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ pub enum Error {
     HTTPError(hyper::error::Error),
 
     /// An error returned by the APIs
-    LastFMError(LastFMErrorResponse)
+    LastFMError(LastFMErrorResponse),
 }
 
 /// Representation of all the LastFM APIs errors
@@ -30,15 +30,15 @@ pub enum LastFMErrorResponse {
     InvalidMethodSignatureSupplied(LastFMError),
     GenericError(LastFMError),
     SuspendedAPIKey(LastFMError),
-    RateLimitExceeded(LastFMError)
+    RateLimitExceeded(LastFMError),
 }
 
 /// A generic LastFM response when the request can't be accomplished.
 #[derive(Deserialize, Debug)]
 pub struct LastFMError {
-    pub error:   i32,
+    pub error: i32,
     pub message: String,
-    pub links:   Vec<String>
+    pub links: Vec<String>,
 }
 
 impl From<LastFMError> for LastFMErrorResponse {
@@ -58,7 +58,7 @@ impl From<LastFMError> for LastFMErrorResponse {
             16 => LastFMErrorResponse::GenericError(lastm_error),
             26 => LastFMErrorResponse::SuspendedAPIKey(lastm_error),
             29 => LastFMErrorResponse::RateLimitExceeded(lastm_error),
-            _  => LastFMErrorResponse::GenericError(lastm_error)
+            _ => LastFMErrorResponse::GenericError(lastm_error),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-#[macro_use] extern crate serde_derive;
+#[macro_use]
+extern crate serde_derive;
 extern crate serde;
 extern crate serde_json;
 extern crate hyper;
@@ -28,7 +29,7 @@ type HTTPResult = hyper::error::Result<hyper::client::response::Response>;
 #[derive(Deserialize)]
 pub struct RawData {
     #[serde(rename = "#text")]
-    pub text: String
+    pub text: String,
 }
 
 impl fmt::Debug for RawData {
@@ -44,21 +45,21 @@ impl fmt::Display for RawData {
 }
 
 pub struct RequestBuilder<'a, T: 'a> {
-    client:  &'a mut Client,
-    url:     Url,
-    phantom: PhantomData<&'a T>
+    client: &'a mut Client,
+    url: Url,
+    phantom: PhantomData<&'a T>,
 }
 
 pub struct Client {
-    api_key:     String,
-    http_client: HTTPClient
+    api_key: String,
+    http_client: HTTPClient,
 }
 
 impl Client {
     pub fn new(api_key: &str) -> Client {
         Client {
-            api_key:     api_key.to_owned(),
-            http_client: HTTPClient::new()
+            api_key: api_key.to_owned(),
+            http_client: HTTPClient::new(),
         }
     }
 
@@ -66,7 +67,8 @@ impl Client {
     fn build_url(&self, params: Vec<(&str, &str)>) -> Url {
         let mut url = Url::parse("http://ws.audioscrobbler.com/2.0/").unwrap();
 
-        url.query_pairs_mut().clear()
+        url.query_pairs_mut()
+            .clear()
             .append_pair("api_key", &*self.api_key)
             .append_pair("format", "json");
 
@@ -96,19 +98,20 @@ mod tests {
     #[test]
     fn test_build_url() {
         let api_key = env::var("API_KEY").unwrap();
-        let user    = env::var("USER").unwrap();
+        let user = env::var("USER").unwrap();
 
         let client = make_client();
-        let url    = client.build_url(vec![
-                                      ("method", "user.getrecenttracks"),
-                                      ("user",   &user)
-        ]);
+        let url = client.build_url(vec![("method", "user.getrecenttracks"), ("user", &user)]);
 
         assert_eq!(url.as_str(),
-            &format!("http://ws.audioscrobbler.com/2.0/?api_key={}&format=json&method=user.getrecenttracks&user={}", api_key, user));
+                   &format!("http://ws.audioscrobbler.com/2.\
+                             0/?api_key={}&format=json&method=user.getrecenttracks&user={}",
+                            api_key,
+                            user));
 
         let url = client.build_url(vec![]);
         assert_eq!(url.as_str(),
-            &format!("http://ws.audioscrobbler.com/2.0/?api_key={}&format=json", api_key));
+                   &format!("http://ws.audioscrobbler.com/2.0/?api_key={}&format=json",
+                            api_key));
     }
 }

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -3,5 +3,5 @@ pub mod recent_tracks;
 #[derive(Debug, Deserialize)]
 pub struct User {
     #[serde(rename = "recenttracks")]
-    pub recent_tracks: Option<recent_tracks::RecentTracks>
+    pub recent_tracks: Option<recent_tracks::RecentTracks>,
 }

--- a/src/user/recent_tracks.rs
+++ b/src/user/recent_tracks.rs
@@ -9,34 +9,35 @@ use error::{LastFMError, Error};
 #[derive(Debug, Deserialize)]
 pub struct RecentTracks {
     #[serde(rename = "track")]
-    pub tracks: Vec<Track>
+    pub tracks: Vec<Track>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct Track {
     pub artist: RawData,
-    pub name:   String,
-    pub album:  RawData,
-    pub url:    String,
+    pub name: String,
+    pub album: RawData,
+    pub url: String,
     #[serde(rename = "image")]
     pub images: Vec<RawData>,
-    pub date:   Option<RawData>
+    pub date: Option<RawData>,
 }
 
 impl RecentTracks {
     pub fn build<'a>(client: &'a mut Client, user: &str) -> RequestBuilder<'a, RecentTracks> {
-        let url = client.build_url(vec![
-                                   ("method", "user.getRecentTracks"),
-                                   ("user",   user)
-        ]);
+        let url = client.build_url(vec![("method", "user.getRecentTracks"), ("user", user)]);
 
-        RequestBuilder { client: client, url: url, phantom: PhantomData }
+        RequestBuilder {
+            client: client,
+            url: url,
+            phantom: PhantomData,
+        }
     }
 }
 
 impl<'a> RequestBuilder<'a, RecentTracks> {
     add_param!(with_limit, limit, u32);
-    add_param!(with_page,  page,  u32);
+    add_param!(with_page, page, u32);
 
     pub fn send(&'a mut self) -> Result<RecentTracks, Error> {
         match self.client.request(&self.url) {
@@ -49,12 +50,12 @@ impl<'a> RequestBuilder<'a, RecentTracks> {
                     Err(_) => {
                         match serde_json::from_str::<User>(&*body) {
                             Ok(user) => Ok(user.recent_tracks.unwrap()),
-                            Err(e)   => Err(Error::ParsingError(e))
+                            Err(e) => Err(Error::ParsingError(e)),
                         }
                     }
                 }
-            },
-            Err(err) => Err(Error::HTTPError(err))
+            }
+            Err(err) => Err(Error::HTTPError(err)),
         }
     }
 }
@@ -71,8 +72,8 @@ mod tests {
 
     #[test]
     fn test_recent_tracks() {
-        let mut client        = make_client();
-        let     recent_tracks = client.recent_tracks("RoxasShadow")
+        let mut client = make_client();
+        let recent_tracks = client.recent_tracks("RoxasShadow")
             .with_limit(1)
             .send();
         assert!(recent_tracks.is_ok());
@@ -80,9 +81,10 @@ mod tests {
 
     #[test]
     fn test_recent_tracks_not_found() {
-        let mut client        = make_client();
-        let     recent_tracks = client.recent_tracks("nonesistinonesistinonesisti").send();
+        let mut client = make_client();
+        let recent_tracks = client.recent_tracks("nonesistinonesistinonesisti").send();
         assert_eq!(&*format!("{:?}", recent_tracks),
-           "Err(LastFMError(InvalidParameter(LastFMError { error: 6, message: \"User not found\", links: [] })))");
+                   "Err(LastFMError(InvalidParameter(LastFMError { error: 6, message: \"User not \
+                    found\", links: [] })))");
     }
 }


### PR DESCRIPTION
This commit has had RustFMT run over the existing code, and format it
accordingly.

If you don't want to accept this PR, that's fine, but I highly recommend RustFMT- it does a good job of making the code look cleaner.

Also, FWIW, I tested this crate, and it seems to work as expected. There are no breakages, as far as I can see.